### PR TITLE
Fix test coverage of BIG_VECTOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Allow a `slice` to be passed to `fizzbuzzo3.fizzbuzz` - this provides a further 1.5x speed increase over passing a list with the same elements.
 - Build rust with `--release` optimisations - another 4-7x speed increase.
 
+## Rust 3.0.2
+
+- Fix dedicated test case for big vector.
+
 ## Rust 3.0.1
 
 - Additional test case validating use case for stepped range, no code changes required.

--- a/rust/fizzbuzz/Cargo.toml
+++ b/rust/fizzbuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fizzbuzz"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 
 [lib]

--- a/rust/fizzbuzz/src/lib.rs
+++ b/rust/fizzbuzz/src/lib.rs
@@ -144,7 +144,7 @@ mod test {
 
     #[test]
     fn big_vector_is_well_ordered() {
-        let input: Vec<_> = (1..BIG_VECTOR + 1).collect();
+        let input: Vec<_> = (1..BIG_VECTOR + 2).collect();
         let output: Vec<_> = input.clone().fizzbuzz().into();
         let mut expected: Vec<String> = vec![];
         for i in input.iter() {


### PR DESCRIPTION
Local coverage checks were green, pipeline red. Better safe than sorry.