### PR TITLE
Fix: MacOS14 CIBW bug (won't move wheel after test)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@
 
     [tool.cibuildwheel.macos]
         before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && cargo install just && just clean"
+        before-build = "pwd && ls -al"
+        before-test = "pwd && ls -al"
 
     [tool.cibuildwheel.windows]
         before-all = "rustup target add aarch64-pc-windows-msvc i586-pc-windows-msvc i686-pc-windows-msvc x86_64-pc-windows-msvc && cargo install just && just clean"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,7 @@
         archs = "all"
 
     [tool.cibuildwheel.macos]
-        before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && cargo install just && just clean"
-        before-build = "pwd && ls -al"
-        before-test = "pwd && ls -al"
+        before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && cargo install just && just clean && mkdir wheelhouse"
 
     [tool.cibuildwheel.windows]
         before-all = "rustup target add aarch64-pc-windows-msvc i586-pc-windows-msvc i686-pc-windows-msvc x86_64-pc-windows-msvc && cargo install just && just clean"


### PR DESCRIPTION
pathlib.Path.unlink appears to throw a NotADirectoryError on Macos, CIBW only supresses a FileNotFoundError, which is what Pathlib documents (!)