### PR TITLE
use cibw fix from fork

### DIFF
--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: musicalninjadad/cibuildwheel@MusicalNinjaDad/issue1850
         env:
           CIBW_BUILD: ${{ matrix.target }}
         # with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@
         archs = "all"
 
     [tool.cibuildwheel.macos]
-        before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && cargo install just && just clean && mkdir wheelhouse"
+        before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && cargo install just && just clean"
 
     [tool.cibuildwheel.windows]
         before-all = "rustup target add aarch64-pc-windows-msvc i586-pc-windows-msvc i686-pc-windows-msvc x86_64-pc-windows-msvc && cargo install just && just clean"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflow to use a forked version of cibuildwheel for building Python wheels, addressing an issue in the original cibuildwheel repository.

* **CI**:
    - Updated the GitHub Actions workflow to use a forked version of cibuildwheel for building wheels.

<!-- Generated by sourcery-ai[bot]: end summary -->